### PR TITLE
Add some ergonomics improvements

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 //! ## usage
 //!
 //! ### tokenisation
-//! 
+//!
 //! ```
 //! let bytes = b"@id=123 :jess!~jess@hostname PRIVMSG #chat :hello there!";
 //! let line = irctokens::Line::tokenise(bytes).unwrap();

--- a/src/obj.rs
+++ b/src/obj.rs
@@ -3,7 +3,7 @@ use std::collections::BTreeMap;
 /// A struct representing all the constituent pieces of an RFC1459/IRCv3 protocol line.
 ///
 /// `@tagkey=tagvalue :source COMMAND arg1 arg2 :arg3 with space`
-#[derive(Debug)]
+#[derive(Clone, PartialEq, Eq, Hash, Debug)]
 pub struct Line {
     /// [Message tags] of an IRC line.
     /// [`None`] if no message tags were present.

--- a/src/tokenise.rs
+++ b/src/tokenise.rs
@@ -5,7 +5,7 @@ use super::Line;
 
 const TAG_STOP: [&[u8]; 2] = [b"", b"="];
 
-#[derive(Debug)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum Error {
     /// An empty byte array was passed to the tokeniser.
     Empty,
@@ -18,6 +18,20 @@ pub enum Error {
     /// Message tag values must be utf8 encoded.
     TagValueDecode,
 }
+
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Error::Empty => write!(f, "empty slice passed to tokeniser"),
+            Error::MissingCommand => write!(f, "missing command"),
+            Error::CommandDecode => write!(f, "commands must be ascii encoded"),
+            Error::TagKeyDecode => write!(f, "message tag keys must be utf8 encoded"),
+            Error::TagValueDecode => write!(f, "message tag values must be utf8 encoded"),
+        }
+    }
+}
+
+impl std::error::Error for Error {}
 
 fn tag_decode(input: &str) -> String {
     let mut escaped = false;

--- a/src/tokenise.rs
+++ b/src/tokenise.rs
@@ -54,7 +54,8 @@ impl Line {
     ///
     /// [RFC1459]: https://www.rfc-editor.org/rfc/rfc1459#section-2.3
     /// [IRCv3]: https://ircv3.net/specs/extensions/message-tags.html
-    pub fn tokenise(mut line: &[u8]) -> Result<Self, Error> {
+    pub fn tokenise(line: impl std::convert::AsRef<[u8]>) -> Result<Self, Error> {
+        let mut line = line.as_ref();
         let tags = if line.first() == Some(&b'@') {
             let mut tags = &line.take_word(b' ')[1..];
             let mut tags_map = BTreeMap::new();


### PR DESCRIPTION
Implements some more traits on Line and Error.

Add `Line::write_to()` for writing to (ideally buffered) `Write`s (such as `Vec`).
Also rewrite `Line::format()` to use this new function,
and adapt `tag_encode` to better-fit how it's used in `Line::write_to`.

Allow `Line::tokenise` to take any `AsRef<[u8]>`.

Further possible improvements to what I've done here:
- Maybe use [thiserror](https://docs.rs/thiserror) for implementing `Display` and `Error`.
- `tag_encode` can be rewritten to use many fewer writes. It's probably fine.
- Actually instantiate `Error::Empty`.

